### PR TITLE
Update mineru_pipeline_all.py

### DIFF
--- a/mineru_pipeline_all.py
+++ b/mineru_pipeline_all.py
@@ -35,7 +35,8 @@ def parse_all_pdfs(datas_dir, output_base_dir):
             f_dump_middle_json=False,
             f_dump_model_output=False,
             f_dump_orig_pdf=False,
-            f_dump_content_list=True
+            f_dump_content_list=True,
+            table_enable=False  # 禁用表格解析
         )
         print(f"已输出: {output_dir / 'auto' / (file_name + '_content_list.json')}")
 


### PR DESCRIPTION
如果表格识别不是核心需求，修改 mineru_pipeline_all.py 禁用表格解析，避免 RapidTableModel 相关问题：


编辑 mineru_pipeline_all.py：
编辑 /kaggle/working/spark_multi_rag/mineru_pipeline_all.py，在 parse_all_pdfs 函数中添加 table_enable=False：